### PR TITLE
Fix missing help message in touk-bash-git

### DIFF
--- a/review
+++ b/review
@@ -78,16 +78,6 @@ printHelp() {
     br
 }
 
-printRemoteHelp() {
-    br
-    put "Example remote configuration:"
-    put "[remote \"origin\"]"
-    put "    url = ssh://john@review.example.com:29418/duhproject"
-    br
-    put "You can add upstream with: git remote add <remote name> <remote url>"
-    br
-}
-
 # $1 - branch core name without number
 # $2 - last rev branch for this core branch name
 createRevBranch() {

--- a/touk-bash-git.sh
+++ b/touk-bash-git.sh
@@ -29,7 +29,7 @@
 verifyEverythingIsCommitted() {
     gitCommitStatus=$(git status --porcelain)
     if [ "$gitCommitStatus" != "" ]; then
-        warn  "You have uncommitted files."
+        warn "You have uncommitted files."
         put "Your git status:"
         exe git status
         put "Sorry. Rules are rules. Aborting!"
@@ -135,7 +135,13 @@ verifyUpstreamExists() {
     if [ "$remotes" == "" ]; then
         warn "There is no remote with name $1. Aborting!"
         exe git remote -v
-        printRemoteHelp
+        br
+        put "Example remote configuration:"
+        put "[remote \"origin\"]"
+        put "    url = ssh://john@review.example.com:29418/duhproject"
+        br
+        put "You can add upstream with: git remote add <remote name> <remote url>"
+        br
         exit 1
     fi
 


### PR DESCRIPTION
Fixes the missing message printing function by moving code to the right script file. On top of that – since it's the only usage of the function – it inlines the message code into the consuming function.

Minor polish on top of that – as usual. 😎